### PR TITLE
SQL Server xml datatype column has nil value for type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 **Typus** allows trusted users to edit structured content.
 
+## This fork
+
+- Treat a SQLServer xml datatype as text. (An xml column from the SQLServer adapter currently has a type of nil).
+- Raise a meaningful exception if an ActiveRecord column has a nil type and there is no workaround.
+
 ## Key Features
 
 - Built-in Authentication and Access Control Lists.

--- a/lib/typus/orm/active_record/class_methods.rb
+++ b/lib/typus/orm/active_record/class_methods.rb
@@ -8,7 +8,7 @@ module Typus
         # Model fields as an <tt>ActiveSupport::OrderedHash</tt>.
         def model_fields
           ActiveSupport::OrderedHash.new.tap do |hash|
-            columns.map { |u| hash[u.name.to_sym] = u.type.to_sym }
+            columns.map { |u| hash[u.name.to_sym] = u.type.nil? ? typus_sql_type_to_ruby_type(u.sql_type) : u.type.to_sym }
           end
         end
 
@@ -98,6 +98,18 @@ module Typus
                 fields_with_type[field.to_s] = attribute_type
               end
             end
+          end
+        end
+
+        private
+
+        # If an ActiveRecord column has a nil +type+ attribute, return a useful symbol based on the column's +sql_type+.
+        def typus_sql_type_to_ruby_type( sql_type )
+          case sql_type
+          when 'xml'
+            :text
+          else
+            raise "Typus does not know how to handle '#{sql_type}' SQL datatype" 
           end
         end
 

--- a/test/fixtures/rails_app/app/models/document.rb
+++ b/test/fixtures/rails_app/app/models/document.rb
@@ -1,0 +1,4 @@
+class Document < ActiveRecord::Base
+
+end
+

--- a/test/fixtures/rails_app/db/schema.rb
+++ b/test/fixtures/rails_app/db/schema.rb
@@ -197,4 +197,12 @@ ActiveRecord::Schema.define do
     t.string :domain, :null => false
   end
 
+  ##
+  # Non-standard datatype
+  #
+
+  create_table :documents, :force => true do |t|
+    t.xml :document
+  end
+
 end

--- a/test/lib/typus/orm/active_record/class_methods_test.rb
+++ b/test/lib/typus/orm/active_record/class_methods_test.rb
@@ -42,6 +42,28 @@ class ClassMethodsTest < ActiveSupport::TestCase
       assert_equal expected.map { |i| i.last }, Post.model_fields.values
     end
 
+    should "verify Document model_fields" do
+      Document.columns.last.stubs(:type).returns(nil)
+      Document.columns.last.stubs(:sql_type).returns('xml')
+      expected = [[:id, :integer],
+                  [:document, :text]]
+
+      assert_equal expected.map { |i| i.last }, Document.model_fields.values
+    end
+
+  end
+
+  context "typus_sql_type_to_ruby_type" do
+
+    should "return text for an xml sql type" do
+      assert_equal :text, TypusUser.send( :typus_sql_type_to_ruby_type, 'xml')
+    end
+
+    should "raise error when sql type is unknown" do
+      assert_raises RuntimeError do
+        TypusUser.send(:typus_sql_type_to_ruby_type, 'bogus')
+      end
+    end
   end
 
   context "model_relationships" do


### PR DESCRIPTION
This works around a problem with the activerecord-sqlserver-adapter.

A field in a SQL Server database with an sql datatype of xml has nil in its `ActiveRecord::ConnectionAdapters::SQLServerColumn#type` attribute. Typus bombs when attempting to create a hash of the model fields.

This change returns a `type` of `:text` and also will raise an exception for any other `sql_type` with a nil `type`.