### PR TITLE
use bootstrapcdn, fixes #464

### DIFF
--- a/app/assets/javascripts/typus/application.js
+++ b/app/assets/javascripts/typus/application.js
@@ -1,6 +1,5 @@
 //= require typus/jquery-2.1.1.min
 //= require jquery_ujs
-//= require bootstrap
 //= require typus/jquery.application
 //= require typus/custom
 

--- a/app/assets/stylesheets/typus/application.css
+++ b/app/assets/stylesheets/typus/application.css
@@ -1,0 +1,5 @@
+/*
+*= require typus/signin
+*= require typus/overrides
+*= require typus/custom
+*/

--- a/app/assets/stylesheets/typus/application.css.scss
+++ b/app/assets/stylesheets/typus/application.css.scss
@@ -1,6 +1,0 @@
-@import 'bootstrap-sprockets';
-@import 'bootstrap';
-@import 'typus/signin';
-@import 'typus/overrides';
-@import 'typus/custom';
-

--- a/app/views/admin/shared/_head.html.erb
+++ b/app/views/admin/shared/_head.html.erb
@@ -9,6 +9,9 @@
 <%= stylesheet_link_tag 'typus/application' %>
 <%= javascript_include_tag 'typus/application' %>
 
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
+
 <%= yield :stylesheets -%>
 <%= yield :javascripts -%>
 

--- a/lib/typus/engine.rb
+++ b/lib/typus/engine.rb
@@ -1,4 +1,3 @@
-require 'bootstrap-sass'
 module Admin
   class Engine < Rails::Engine
   end

--- a/typus.gemspec
+++ b/typus.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rails', '~> 4.1'
   spec.add_dependency 'bcrypt', '~> 3.1.5'
-  spec.add_dependency 'bootstrap-sass', '~> 3.3.1'
 end


### PR DESCRIPTION
This removes the bootstrap gem dependency to avoid conflicts when the app is using a different version.

I tried various ways, but could not get the icons to compile via the asset pipeline correctly in production.

Using the bootstrap CDN avoids this issue.