### PR TITLE
re-enable custom resource actions

### DIFF
--- a/app/views/admin/resources/_form.html.erb
+++ b/app/views/admin/resources/_form.html.erb
@@ -13,6 +13,9 @@
     <% end %>
     <%= hidden_field_tag '_continue' %>
   <% else %>
+    <% resources_actions_for_current_role.map do |body, url, options| %>
+      <%= link_to t(body), params.dup.merge!(url).compact.cleanup, options || {class: 'btn btn-default'} %>
+    <% end %>
     <% build_save_options.each do |key, value, special| %>
       <%
         klass = key.eql?(:_save) ? 'btn btn-primary' : 'btn btn-default'


### PR DESCRIPTION
as far as i can see custom actions on resources ie the edit page are not supported right now?

i provided a extremely minimal way to add them back. this can probably be done much nicer.

unfortunately, this also adds a legacy feature [`Back to list`](https://github.com/typus/typus/blob/master/app/controllers/concerns/admin/navigation.rb#L20) which does not even have a translation with it...