### PR TITLE
Fix for Ruby 2.2 parameter aliasing issue

### DIFF
--- a/app/helpers/admin/resources/filters_helper.rb
+++ b/app/helpers/admin/resources/filters_helper.rb
@@ -1,6 +1,6 @@
 module Admin::Resources::FiltersHelper
 
-  def build_filters(resource = @resource, params = params)
+  def build_filters(resource = @resource, local_params = params)
     if (typus_filters = resource.typus_filters).any?
       locals = {}
 
@@ -10,7 +10,7 @@ module Admin::Resources::FiltersHelper
                          end
 
       rejections = %w(controller action locale utf8 sort_order order_by) + locals[:filters].map { |f| f[:key] }
-      locals[:hidden_filters] = params.dup.delete_if { |k, v| rejections.include?(k) }
+      locals[:hidden_filters] = local_params.dup.delete_if { |k, v| rejections.include?(k) }
 
       render "helpers/admin/resources/filters", locals
     end

--- a/app/helpers/admin/resources/table_helper.rb
+++ b/app/helpers/admin/resources/table_helper.rb
@@ -13,26 +13,26 @@ module Admin::Resources::TableHelper
     render "helpers/admin/resources/table", locals
   end
 
-  def table_header(model, fields, params = params)
+  def table_header(model, fields, local_params = params)
     fields.map do |key, value|
 
       key = key.gsub(".", " ") if key.to_s.match(/\./)
       content = model.human_attribute_name(key)
 
-      if params[:action].eql?('index') && model.typus_options_for(:sortable)
+      if local_params[:action].eql?('index') && model.typus_options_for(:sortable)
         association = model.reflect_on_association(key.to_sym)
         order_by = association ? association.foreign_key : key
 
         if (model.model_fields.map(&:first).map(&:to_s).include?(key) || model.reflect_on_all_associations(:belongs_to).map(&:name).include?(key.to_sym))
-          sort_order = case params[:sort_order]
+          sort_order = case local_params[:sort_order]
                        when 'asc' then ['desc', '&darr;']
                        when 'desc' then ['asc', '&uarr;']
                        else [nil, nil]
                        end
-          switch = sort_order.last if params[:order_by].eql?(order_by)
+          switch = sort_order.last if local_params[:order_by].eql?(order_by)
           options = { :order_by => order_by, :sort_order => sort_order.first }
           message = [content, switch].compact.join(" ").html_safe
-          content = link_to(message, params.merge(options))
+          content = link_to(message, local_params.merge(options))
         end
       end
 

--- a/app/helpers/admin/resources_helper.rb
+++ b/app/helpers/admin/resources_helper.rb
@@ -1,9 +1,9 @@
 module Admin::ResourcesHelper
 
-  def admin_search(resource = @resource, params = params)
+  def admin_search(resource = @resource, local_params = params)
     if (typus_search = resource.typus_defaults_for(:search)) && typus_search.any?
 
-      hidden_filters = params.dup
+      hidden_filters = local_params.dup
       rejections = %w(controller action locale utf8 sort_order order_by search page)
       hidden_filters.delete_if { |k, v| rejections.include?(k) }
 


### PR DESCRIPTION
When I upgraded to Ruby 2.2 I started seeing "can't dup nil" errors which were fixed by this change.  

I'm not quite sure what changed to cause this... if I get a chance I'll dig in a bit more. EDIT ah I see https://bugs.ruby-lang.org/issues/10314