### PR TITLE
Make sure the model exactly includes ancestry

### DIFF
--- a/app/helpers/admin/resources/data_types/belongs_to_helper.rb
+++ b/app/helpers/admin/resources/data_types/belongs_to_helper.rb
@@ -12,7 +12,7 @@ module Admin::Resources::DataTypes::BelongsToHelper
     related_fk = association.foreign_key
     label_text = @resource.human_attribute_name(attribute)
 
-    values = if related.respond_to?(:roots)
+    values = if related.respond_to?(:roots) && related.respond_to?(:ancestry_column)
       expand_tree_into_select_field(related.roots, related_fk)
     else
       related.order(related.typus_order_by).map { |p| [p.to_label, p.id] }


### PR DESCRIPTION
because the gem, `awesome_nested_set` also includes `.roots` method into
model and this causes wrong behavior with belongs_to_helper.