### PR TITLE
Admin user fixes

### DIFF
--- a/app/helpers/admin/resources/form_helper.rb
+++ b/app/helpers/admin/resources/form_helper.rb
@@ -78,7 +78,7 @@ module Admin::Resources::FormHelper
   end
 
   def save_options_for_user_class
-    return unless !defined?(Typus.user_class) && Typus.user_class == @resource && admin_user.is_not_root?
+    return unless defined?(Typus.user_class) && Typus.user_class == @resource && admin_user.is_not_root?
     { _continue: 'typus.buttons.save_continue' }
   end
 

--- a/lib/typus/authentication/session.rb
+++ b/lib/typus/authentication/session.rb
@@ -42,7 +42,8 @@ module Typus
       # Action is available on: edit, update, toggle and destroy
       #++
       def check_if_user_can_perform_action_on_user
-        is_current_user = (admin_user == @item)
+        user = @item
+        is_current_user = (admin_user == user)
         current_user_is_root = admin_user.is_root? && is_current_user
 
         case params[:action]
@@ -53,18 +54,18 @@ module Typus
         when 'toggle', 'destroy'
           not_allowed if admin_user.is_not_root? || current_user_is_root
         when 'update'
-          # Admin can update himself except setting the status to false!. Other
-          # users can update their profile as the attributes (role & status)
-          # are protected.
-          status_as_boolean = params[@object_name][:status] == '1' ? true : false
+          # Admin can update himself except setting his own status or role
+          status = params[@object_name][:status]
+          status_as_boolean = status == '1' ? true : false
 
-          status_changed = !(@item.status == status_as_boolean)
-          role_changed = !(@item.role == params[@object_name][:role])
+          status_changed = false
+          status_changed = user.status != status_as_boolean if status 
 
-          root_changed_his_status_or_role = current_user_is_root && (status_changed || role_changed)
+          role_changed = !(user.role == params[@object_name][:role])
+          user_changed_his_status_or_role =  is_current_user && (status_changed || role_changed)
+
           not_root_tries_to_change_another_user = admin_user.is_not_root? && !is_current_user
-
-          not_allowed if root_changed_his_status_or_role || not_root_tries_to_change_another_user
+          not_allowed if user_changed_his_status_or_role || not_root_tries_to_change_another_user
         end
       end
 

--- a/lib/typus/orm/active_record/admin_user.rb
+++ b/lib/typus/orm/active_record/admin_user.rb
@@ -73,7 +73,7 @@ module Typus
         end
 
         def password_must_be_strong(count = 6)
-          if password.present? && password.size < count
+          if !password.nil? && password.size < count
             errors.add(:password, :too_short, count: count)
           end
         end

--- a/test/controllers/admin/resources/typus_users_controller_test.rb
+++ b/test/controllers/admin/resources/typus_users_controller_test.rb
@@ -113,7 +113,7 @@ class Admin::TypusUsersControllerTest < ActionController::TestCase
     post :update, id: @typus_user.id, typus_user: { role: 'admin' }, _continue: true
     assert_response :redirect
     assert_redirected_to "/admin/typus_users/edit/#{@typus_user.id}"
-    assert_equal "editor", @typus_user.role
+    assert_equal "editor", @typus_user.reload.role
   end
 
   test "editor should not be able to destroy his profile" do

--- a/test/controllers/admin/resources/typus_users_controller_test.rb
+++ b/test/controllers/admin/resources/typus_users_controller_test.rb
@@ -111,8 +111,7 @@ class Admin::TypusUsersControllerTest < ActionController::TestCase
   test "editor should not be able to change his role" do
     editor_sign_in
     post :update, id: @typus_user.id, typus_user: { role: 'admin' }, _continue: true
-    assert_response :redirect
-    assert_redirected_to "/admin/typus_users/edit/#{@typus_user.id}"
+    assert_response :unprocessable_entity
     assert_equal "editor", @typus_user.reload.role
   end
 

--- a/test/controllers/admin/resources/typus_users_controller_test.rb
+++ b/test/controllers/admin/resources/typus_users_controller_test.rb
@@ -98,6 +98,7 @@ class Admin::TypusUsersControllerTest < ActionController::TestCase
     editor_sign_in
     get :edit, id: @typus_user.id
     assert_response :success
+    assert_select 'form input[name=_continue]'
   end
 
   test "editor should be able to update his profile" do

--- a/test/models/admin_user_test.rb
+++ b/test/models/admin_user_test.rb
@@ -41,6 +41,9 @@ class AdminUserTest < ActiveSupport::TestCase
     assert_equal 'is too short (minimum is 6 characters)', typus_user.errors[:password].first
     typus_user.password = '000000'
     assert typus_user.valid?
+    typus_user.password = ''
+    assert_not typus_user.valid?
+    assert_equal 'is too short (minimum is 6 characters)', typus_user.errors[:password].first
   end
 
 end


### PR DESCRIPTION
* Don't allow user to change his role or status
* Allow user to change himself
* Do not allow passwords to be empty 
...

There is room for improvement as a user now always has to update his password, but at least it won't be set to an empty string.