### PR TITLE
bugfix: search box's path  don't consider subdomain.

### DIFF
--- a/app/helpers/admin/base_helper.rb
+++ b/app/helpers/admin/base_helper.rb
@@ -70,7 +70,7 @@ module Admin::BaseHelper
   end
 
   def typus_search_path
-    "/admin/#{params[:controller].remove_prefix}"
+    File.join("/",params[:controller])
   end
 
 end


### PR DESCRIPTION
When "config.subdomain" value is setted, all system path is changed to "/admin/:controller" to "/:controller".
But search box's path function don't consider.

So,I think and fix!!