### PR TITLE
'id' parameter take over to next page's and pollute searh result.

### DIFF
--- a/app/helpers/admin/resources_helper.rb
+++ b/app/helpers/admin/resources_helper.rb
@@ -4,7 +4,7 @@ module Admin::ResourcesHelper
     if (typus_search = resource.typus_defaults_for(:search)) && typus_search.any?
 
       hidden_filters = params.dup
-      rejections = %w(controller action locale utf8 sort_order order_by search page)
+      rejections = %w(id controller action locale utf8 sort_order order_by search page)
       hidden_filters.delete_if { |k, _| rejections.include?(k) }
 
       render 'helpers/admin/resources/search', hidden_filters: hidden_filters


### PR DESCRIPTION
bugfix about
https://github.com/typus/typus/issues/498
