### PR TITLE
fix ambiguous columns name on order

### DIFF
--- a/app/controllers/admin/resources_controller.rb
+++ b/app/controllers/admin/resources_controller.rb
@@ -187,7 +187,7 @@ class Admin::ResourcesController < Admin::BaseController
   def set_order
     params[:sort_order] ||= 'desc'
 
-    if (order = params[:order_by] ? "#{params[:order_by]} #{params[:sort_order]}" : @resource.typus_order_by).present?
+    if (order = params[:order_by] ? "#{@resource.table_name}.#{params[:order_by]} #{params[:sort_order]}" : @resource.typus_order_by).present?
       @resource = @resource.reorder(order)
     end
   end


### PR DESCRIPTION
ordering a resource that contains has a `join` clause in the `default_scope` will result in an error as the order-by condition might be ambiguous:

```
PG::AmbiguousColumn: ERROR: column reference "id" is ambiguous
LINE 1: ..._id" WHERE "events"."label" = 'hamburg' ORDER BY id asc LIM...
^
: SELECT "materials"."id" AS t0_r0, "materials"."name" AS t0_r1, "materials"."description" AS t0_r2, "materials"."url" AS t0_r3, "materials"."user_id" AS t0_r4, "materials"."event_id" AS t0_r5, "materials"."created_at" AS t0_r6, "materials"."updated_at" AS t0_r7, "materials"."preview_type" AS t0_r8, "materials"."preview_code" AS t0_r9, "users"."id" AS t1_r0, "users"."nickname" AS t1_r1, "users"."name" AS t1_r2, "users"."image" AS t1_r3, "users"."url" AS t1_r4, "users"."location" AS t1_r5, "users"."description" AS t1_r6, "users"."created_at" AS t1_r7, "users"."updated_at" AS t1_r8, "users"."github" AS t1_r9, "users"."admin" AS t1_r10, "users"."freelancer" AS t1_r11, "users"."available" AS t1_r12, "users"."slug" AS t1_r13, "users"."hide_jobs" AS t1_r14, "users"."twitter" AS t1_r15, "users"."email" AS t1_r16, "users"."super_admin" AS t1_r17, "events"."id" AS t2_r0, "events"."name" AS t2_r1, "events"."date" AS t2_r2, "events"."description" AS t2_r3, "events"."location_id" AS t2_
r4, "events"."user_id" AS t2_r5, "events"."created_at" AS t2_r6, "events"."updated_at" AS t2_r7, "events"."published" AS t2_r8, "events"."slug" AS t2_r9, "events"."label" AS t2_r10, "events"."limit" AS t2_r11 FROM "materials" INNER JOIN "events" ON "events"."id" = "materials"."event_id" AND "events"."label" = $1 LEFT OUTER JOIN "users" ON "users"."id" = "materials"."user_id" WHERE "events"."label" = 'hamburg' ORDER BY id asc LIMIT 20 OFFSET 0
```

this change prepends the table-name to resolve it.