### PR TITLE
Fixes table helper #table_actions method

### DIFF
--- a/app/helpers/admin/resources/table_helper.rb
+++ b/app/helpers/admin/resources/table_helper.rb
@@ -63,7 +63,7 @@ module Admin::Resources::TableHelper
         url: params.dup.cleanup.merge({controller: "/admin/#{model.to_resource}", id: item.id}).merge(url),
         options: options,
       }
-    end
+    end.compact
   end
 
 end


### PR DESCRIPTION
A typus resource actions may be configured with a proc which
determines if an action should be rendered for a specific resource instance.

In the case of a false result #table_actions would return a nil value
which would then result in an exception during view rendering.

To fix this issue #compact is called to remove nil values from the
result array.