### PR TITLE
fix has_one association's title translate

### DIFF
--- a/app/views/admin/templates/_has_one.html.erb
+++ b/app/views/admin/templates/_has_one.html.erb
@@ -1,7 +1,7 @@
 <div class="box_relationships" id="<%= association_name %>">
 
   <h2>
-    <%= association_name.titleize.humanize %>
+    <%= @resource.human_attribute_name(association_name) %>
     <small><%= add_new %></small>
   </h2>
 


### PR DESCRIPTION
typus translate has_many/has_one relation's name.
But, when I use it. has_one relation cannnot translate to Japanese.
so, I find bug and fix it.