### PR TITLE
this should be the admin user

### DIFF
--- a/app/controllers/admin/resources_controller.rb
+++ b/app/controllers/admin/resources_controller.rb
@@ -260,7 +260,7 @@ class Admin::ResourcesController < Admin::BaseController
   end
 
   def cleanup_attributes_before_update
-    if Typus.user_class && @item.is_a?(Typus.user_class) && @item.is_not_root?
+    if Typus.user_class && @item.is_a?(Typus.user_class) && admin_user.is_not_root?
       params[Typus.user_class_as_symbol].delete(:role)
     end
   end


### PR DESCRIPTION
when editing users in my app, i get an error:

```
A NoMethodError occurred in users#update:

undefined method `is_not_root?' for #<User:0x007fd1fc70ec68>
app/middlewares/cookie_domain.rb:11:in `call'
```

i think that the `admin_user` instance should be checked, not the user model that will be updated.