### PR TITLE
fix: document link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ pull request with failing specs.
 
 ## Links
 
-- [Documentation](http://docs.typuscmf.com/)
+- [Documentation](https://github.com/typus/typus/wiki/)
 - [RubyGems][typus_gem]
 - [Contributors List](http://github.com/typus/typus/contributors)
 


### PR DESCRIPTION
http://docs.typuscmf.com is expired. So link fix to github's wiki.