### PR TITLE
Fixed search bar's placeholder text change to seachable attribute name.

### DIFF
--- a/app/helpers/admin/resources_helper.rb
+++ b/app/helpers/admin/resources_helper.rb
@@ -2,16 +2,17 @@ module Admin::ResourcesHelper
 
   def admin_search(resource = @resource, params = self.params)
     if (typus_search = resource.typus_defaults_for(:search)) && typus_search.any?
+      placeholder = resource.typus_search_fields.keys.map { |k| resource.human_attribute_name(k) || k } * ","
 
       hidden_filters = params.dup
 
       rejections = %w(id controller action locale utf8 sort_order order_by search page subdomain)
       hidden_filters.delete_if { |k, _| rejections.include?(k.to_s) }
 
-      render "helpers/admin/#{resource.to_resource}/search", hidden_filters: hidden_filters
+      render "helpers/admin/#{resource.to_resource}/search", hidden_filters: hidden_filters, placeholder: placeholder
     end
   rescue ActionView::MissingTemplate
-    render 'helpers/admin/resources/search', hidden_filters: hidden_filters
+    render 'helpers/admin/resources/search', hidden_filters: hidden_filters, placeholder: placeholder
   end
 
   def build_sidebar

--- a/app/views/helpers/admin/resources/_search.html.erb
+++ b/app/views/helpers/admin/resources/_search.html.erb
@@ -5,7 +5,7 @@
       <%= form_tag typus_search_path, method: :get, class: 'form-search' do %>
 
         <div class="input-append">
-          <%= search_field_tag 'search', nil, class: 'form-control input-sm', placeholder: params[:search] %>
+          <%= search_field_tag 'search', nil, class: 'form-control input-sm', value: params[:search], placeholder: placeholder %>
         </div>
 
         <% hidden_filters.each do |key, value| %>

--- a/test/helpers/admin/resources_helper_test.rb
+++ b/test/helpers/admin/resources_helper_test.rb
@@ -11,7 +11,7 @@ class Admin::ResourcesHelperTest < ActiveSupport::TestCase
   setup do
     @expected = [
       'helpers/admin/entries/search',
-      { hidden_filters: {} }
+      { hidden_filters: {}, :placeholder=>"Title" }
     ]
   end
 
@@ -49,7 +49,7 @@ class Admin::ResourcesHelperTest < ActiveSupport::TestCase
     parameters = { published: 'true', user_id: '1' }
     expected = [
       'helpers/admin/entries/search',
-      { hidden_filters: { published: 'true', user_id: '1' } }
+      { hidden_filters: { published: 'true', user_id: '1' }, :placeholder=>"Title" }
     ]
     assert_equal expected, admin_search(Entry, parameters)
   end


### PR DESCRIPTION
I try changing to search bar's placeholder text, because my admin's user desire to fix it.
Generally, I guess that system user wanto to know what I can search. 