### PR TITLE
fix circular reference warning that was causing issues on ruby-2.2.5 and Rails 3.2

### DIFF
--- a/app/helpers/admin/resources/filters_helper.rb
+++ b/app/helpers/admin/resources/filters_helper.rb
@@ -1,6 +1,6 @@
 module Admin::Resources::FiltersHelper
 
-  def build_filters(resource = @resource, params = params)
+  def build_filters(resource = @resource, params = request.params)
     if (typus_filters = resource.typus_filters).any?
       locals = {}
 

--- a/app/helpers/admin/resources/table_helper.rb
+++ b/app/helpers/admin/resources/table_helper.rb
@@ -11,7 +11,7 @@ module Admin::Resources::TableHelper
     render "helpers/admin/resources/table", locals
   end
 
-  def table_header(model, fields, params = params)
+  def table_header(model, fields, params = request.params)
     fields.map do |key, value|
 
       key = key.gsub(".", " ") if key.to_s.match(/\./)

--- a/app/helpers/admin/resources_helper.rb
+++ b/app/helpers/admin/resources_helper.rb
@@ -1,6 +1,6 @@
 module Admin::ResourcesHelper
 
-  def search(resource = @resource, params = params)
+  def search(resource = @resource, params = request.params)
     if (typus_search = resource.typus_defaults_for(:search)) && typus_search.any?
 
       hidden_filters = params.dup


### PR DESCRIPTION
After upgrading our Rails 3.2.22 app to Ruby 2.2.5 (the latest available for 3.2.22), typus was displaying a circular reference warning that also caused the app to 500 since the `params` hash was returning `nil`. I've patched the circular reference and the app is no longer 500ing.