### PR TITLE
Backport Ruby 2.2 fixes to 3-2-stable branch

### DIFF
--- a/app/helpers/admin/resources/filters_helper.rb
+++ b/app/helpers/admin/resources/filters_helper.rb
@@ -1,6 +1,6 @@
 module Admin::Resources::FiltersHelper
 
-  def build_filters(resource = @resource, params = params)
+  def build_filters(resource = @resource, params = self.params)
     if (typus_filters = resource.typus_filters).any?
       locals = {}
 

--- a/app/helpers/admin/resources/table_helper.rb
+++ b/app/helpers/admin/resources/table_helper.rb
@@ -13,7 +13,7 @@ module Admin::Resources::TableHelper
     render "helpers/admin/resources/table", locals
   end
 
-  def table_header(model, fields, params = params)
+  def table_header(model, fields, params = self.params)
     fields.map do |key, value|
 
       key = key.gsub(".", " ") if key.to_s.match(/\./)

--- a/app/helpers/admin/resources_helper.rb
+++ b/app/helpers/admin/resources_helper.rb
@@ -1,6 +1,6 @@
 module Admin::ResourcesHelper
 
-  def admin_search(resource = @resource, params = params)
+  def admin_search(resource = @resource, params = self.params)
     if (typus_search = resource.typus_defaults_for(:search)) && typus_search.any?
 
       hidden_filters = params.dup


### PR DESCRIPTION
I'm working on progressively upgrading my Rails 3.2.22 app to newer versions of Ruby, Rails, and my app's dependencies. I ran into an issue with the `3-2-stable` branch because of changes in Ruby 2.2 behavior. This PR cherry-picks a fix that already exists in the master branch.