### PR TITLE
Fixed: support ActiveRecord::Enum

### DIFF
--- a/app/views/admin/templates/_selector.html.erb
+++ b/app/views/admin/templates/_selector.html.erb
@@ -1,4 +1,4 @@
 <div class="form-group" id="<%= attribute_id %>">
   <%= form.label attribute, label_text, { class: 'control-label' } %>
-  <%= form.select attribute, @resource.send(attribute.pluralize), options, { class: 'form-control' } %>
+  <%= form.select attribute, @resource.try("#{attribute.pluralize}_enum") || @resource.send(attribute.pluralize), options, { class: 'form-control' } %>
 </div>


### PR DESCRIPTION
To get selector's item, Typus uses plualized name's method.
https://github.com/typus/typus/wiki/configuration-resources#selectors

But, when Rails4.1 released. Method name confilected
```ActiveRecord::Enum```'s method name.
so, I research other admin framework gems, and I think best way to
implement enum selector.

1. rails_admin
rails_admin select new method name is like ```"#{column name}_enum"```
https://github.com/sferik/rails_admin/issues/1993

2. active admin
active admin select add to parameter in "collection" option.
http://stackoverflow.com/questions/23414880/how-to-properly-configure-rails-4-1-enums-in-activeadmin

and, ```ActiveRecord::Enum``` have't I18n. so liker a below gems were released
to support this function.

* https://github.com/brainspec/enumerize
* https://github.com/zmbacker/enum_help

so, We should avoid ActieRecord::Enum i18n gem's implement and use
convenient.
I'll follow rails_admin's way.

method name change ```"#{column_name}"``` to ```"{column_name}_enum"```.

```
class Video < ActiveRecord::Base
  STATUS = %w(pending encoding encoded error published)
  validates_inclusion_of :status, :in => STATUS
  def self.statuses_enum
    STATUS
  end
end
```
