### PR TITLE
Add support for additional PostgreSQL field types

### DIFF
--- a/app/helpers/admin/resources/data_types/datetime_helper.rb
+++ b/app/helpers/admin/resources/data_types/datetime_helper.rb
@@ -11,6 +11,8 @@ module Admin::Resources::DataTypes::DatetimeHelper
   alias_method :table_timestamp_field, :table_datetime_field
 
   def display_datetime(item, attribute)
+    value = item.send(attribute)
+    return mdash unless value.present?
     I18n.l(item.send(attribute), format: @resource.typus_date_format(attribute))
   end
 

--- a/app/helpers/admin/resources/data_types/has_many_helper.rb
+++ b/app/helpers/admin/resources/data_types/has_many_helper.rb
@@ -1,5 +1,9 @@
 module Admin::Resources::DataTypes::HasManyHelper
 
+  def display_has_many(item, attribute)
+    item.send(attribute).map(&:to_label).join(', ')
+  end
+
   def has_many_filter(filter)
     att_assoc = @resource.reflect_on_association(filter.to_sym)
     class_name = att_assoc.options[:class_name] || filter.classify

--- a/app/helpers/admin/resources/data_types/string_helper.rb
+++ b/app/helpers/admin/resources/data_types/string_helper.rb
@@ -12,8 +12,10 @@ module Admin::Resources::DataTypes::StringHelper
   alias_method :display_float, :display_string
   alias_method :display_integer, :display_string
   alias_method :display_position, :display_string
-  alias_method :display_text, :display_string
   alias_method :display_virtual, :display_string
+  alias_method :display_enum, :display_string
+  alias_method :display_uuid, :display_string
+  alias_method :display_citext, :display_string
 
   def string_filter(filter)
     values = set_context.send(filter.to_s.pluralize).to_a
@@ -35,4 +37,7 @@ module Admin::Resources::DataTypes::StringHelper
   alias_method :table_virtual_field, :table_string_field
   alias_method :table_password_field, :table_string_field
   alias_method :table_json_field, :table_string_field
+  alias_method :table_enum_field, :table_string_field
+  alias_method :table_uuid_field, :table_string_field
+  alias_method :table_citext_field, :table_string_field
 end

--- a/app/helpers/admin/resources/data_types/text_helper.rb
+++ b/app/helpers/admin/resources/data_types/text_helper.rb
@@ -1,6 +1,21 @@
 module Admin::Resources::DataTypes::TextHelper
 
+  def display_text(item, attribute)
+    value = item.send(attribute)
+    if value.present?
+      value.is_a?(Array) ? value.join(", ") : value
+    else
+      mdash
+    end
+  end
+
   def table_text_field(attribute, item)
-    (raw_content = item.send(attribute)).present? ? truncate(raw_content) : mdash
+    raw_content = item.send(attribute)
+    if raw_content.present?
+      raw_content = raw_content.join(", ") if raw_content.is_a?(Array)
+      truncate(raw_content)
+    else
+      mdash
+    end
   end
 end

--- a/app/views/admin/templates/_text.html.erb
+++ b/app/views/admin/templates/_text.html.erb
@@ -6,6 +6,11 @@
 <div class="form-group" id="<%= attribute_id %>">
   <%= form.label attribute, label_text.html_safe, { :class => "control-label" } %>
   <div class="controls">
-    <%= form.text_area attribute, options %>
+    <% if @item.send(attribute).is_a?(Array) %>
+      <% # TODO: Add ability to edit this array %>
+      <%= display_text(@item, attribute) %>
+    <% else %>
+      <%= form.text_area attribute, options %>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
I recently attempted upgrading to Rails 4.2 (from 3.2) and ran into some issues with Typus. Rails now supports a few more Postgres field types, but it seems that Typus did not know how to handle them. This PR adds support for `enum`, `uuid`, `citext`, and array fields. I don't claim to have added complete support, but these changes prevent "method missing" errors for these field types.